### PR TITLE
Update and fix extension

### DIFF
--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -43,7 +43,7 @@ class PageRenderer
             // Get plugin config
             $conf = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['cleverpush'];
             if (!empty($conf['channelId'])) {
-                $scriptTag = '<script src="https://static.cleverpush.com/channel/loader/' . $conf['channelId'] . '.js" async></script>' .
+                $scriptTag = '<script src="https://static.cleverpush.com/channel/loader/' . $conf['channelId'] . '.js" async></script>';
                 $pObj->addFooterData($scriptTag);
             }
         }

--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -43,7 +43,7 @@ class PageRenderer
             // Get plugin config
             $conf = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['cleverpush'];
             if (!empty($conf['channelId'])) {
-                $scriptTag = '<script src="https://static.cleverpush.com/channel/loader/' + $conf['channelId'] + '.js" async></script>' .
+                $scriptTag = '<script src="https://static.cleverpush.com/channel/loader/' . $conf['channelId'] . '.js" async></script>' .
                 $pObj->addFooterData($scriptTag);
             }
         }

--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -44,18 +44,6 @@ class PageRenderer
             $conf = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['cleverpush'];
             if (!empty($conf['channelId'])) {
                 $scriptTag = '<script src="https://static.cleverpush.com/sdk/cleverpush.js" async></script>' .
-                    LF . '<script>' .
-                    LF . 'CleverPush = window.CleverPush || [];' .
-                    LF . 'CleverPush.push([\'init\', { channelId: \'' . $conf['channelId'] . '\' }]);' .
-                    LF . '</script>';
-                $pObj->addFooterData($scriptTag);
-            } else if (!empty($conf['subdomain'])) {
-                // support old code if channelId was not set, yet
-                $scriptTag = '<script>' .
-                    LF . '(function(c,l,v,r,p,s,h){c[\'CleverPushObject\']=p;c[p]=c[p]||function(){(c[p].q=c[p].q||[]).push(arguments)},c[p].l=1*new Date();s=l.createElement(v),h=l.getElementsByTagName(v)[0];s.async=1;s.src=r;h.parentNode.insertBefore(s,h)})(window,document,\'script\',\'//' . $conf['subdomain'] . '.cleverpush.com/loader.js\',\'cleverpush\');' .
-                    LF . 'cleverpush(\'triggerOptIn\');' .
-                    LF . 'cleverpush(\'checkNotificationClick\');' .
-                    LF . '</script>';
                 $pObj->addFooterData($scriptTag);
             }
         }

--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -41,7 +41,7 @@ class PageRenderer
     {
         if (TYPO3_MODE === 'FE') {
             // Get plugin config
-            $conf = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_cleverpush.']['settings.'];
+            $conf = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['cleverpush'];
             if (!empty($conf['channelId'])) {
                 $scriptTag = '<script src="https://static.cleverpush.com/sdk/cleverpush.js" async></script>' .
                     LF . '<script>' .

--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -43,7 +43,7 @@ class PageRenderer
             // Get plugin config
             $conf = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['cleverpush'];
             if (!empty($conf['channelId'])) {
-                $scriptTag = '<script src="https://static.cleverpush.com/sdk/cleverpush.js" async></script>' .
+                $scriptTag = '<script src="https://static.cleverpush.com/channel/loader/' + $conf['channelId'] + '.js" async></script>' .
                 $pObj->addFooterData($scriptTag);
             }
         }

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -1,9 +1,0 @@
-# ------------------------------------------------------------------------------
-# Add CleverPush code
-# ------------------------------------------------------------------------------
-plugin.tx_cleverpush {
-	settings {
-		# cat=CleverPush//1; type=string; label=LLL:EXT:cleverpush/Resources/Private/Language/locallang.xlf:settings.channelId
-		channelId =
-	}
-}

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,8 +1,0 @@
-# ------------------------------------------------------------------------------
-# Add CleverPush trackingcode
-# ------------------------------------------------------------------------------
-plugin.tx_cleverpush {
-	settings {
-		channelId = {$plugin.tx_cleverpush.settings.channelId}
-	}
-}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=Basic; type=string; label=LLL:EXT:cleverpush/Resources/Private/Language/locallang.xlf:settings.channelId
+channelId =

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -32,7 +32,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'constraints' =>
     [
         'depends' => [
-            'typo3' => '6.2.0-7.6.99',
+            'typo3' => '6.2.0',
         ],
         'conflicts' => [
         ],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,6 +4,5 @@ defined('TYPO3_MODE') or die();
 
 if (TYPO3_MODE === 'FE') {
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][] =
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) .
-        'Classes/Hooks/PageRenderer.php:CleverPush\\Hooks\\PageRenderer->renderPreProcess';
+            \CleverPush\Hooks\PageRenderer::class . '->renderPreProcess';
 }


### PR DESCRIPTION
Ich habe $_EXTKEY Variable gegen String 'cleverpush' beim Test ersetzt um den Fehler 'no extension key found' zu beseitigen.
in [Docs](https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/DeclarationFile/Index.html) steht es muss immer $_EXTKEY da sein und kein String oder Constant, da es eine Globale Variable und wird mit dem Extension Key ersetzt.